### PR TITLE
Remove outdated info that Figma is maintained by Adobe

### DIFF
--- a/public/content/letters/README.mdx
+++ b/public/content/letters/README.mdx
@@ -1,6 +1,6 @@
 # Letters to IT & Administrators
 
-Hack Clubs allow creative students to create technical projects. Tools such as [GitHub](https://github.com/)(maintained by Microsoft), [Figma](https://www.figma.com/)(maintained by Adobe), and [Replit](https://replit.com/) are widely used in the tech industry and play a vital role in empowering creators. Hack Clubs around the world use these tools to build awesome projects, but sometimes schools or districts may block these tools. As a Hack Club leader, you can contact your school or district’s IT department requesting that they unblock these websites, so your Hack Club can do what they do best: build awesome projects together.
+Hack Clubs allow creative students to create technical projects. Tools such as [GitHub](https://github.com/)(maintained by Microsoft), [Figma](https://www.figma.com/), and [Replit](https://replit.com/) are widely used in the tech industry and play a vital role in empowering creators. Hack Clubs around the world use these tools to build awesome projects, but sometimes schools or districts may block these tools. As a Hack Club leader, you can contact your school or district’s IT department requesting that they unblock these websites, so your Hack Club can do what they do best: build awesome projects together.
 
 Below, we’ve provided a couple of examples of letters sent to IT departments in hopes of getting these core tools unblocked. We hope these letters inspire you to reach out to your school’s IT Department and request that the tools your Hack Club need get unblocked!
 


### PR DESCRIPTION
[Figma is not maintained by Adobe](https://www.figma.com/blog/adobe-figma-faq/). This PR removes that information, bringing it up to date. It may look better to also remove the GitHub one, as it may look a little better, but I think this works by removing the incorrect info and still showing that we work with established tools. https://hackclub.slack.com/archives/C0C78SG9L/p1773797205192179 (thread where this was brought up)